### PR TITLE
feat: use download action

### DIFF
--- a/packages/svelteui-actions/src/lib/index.ts
+++ b/packages/svelteui-actions/src/lib/index.ts
@@ -1,4 +1,5 @@
 export { clickoutside } from './use-click-outside/use-click-outside.js';
 export { clipboard } from './use-clipboard/use-clipboard.js';
 export { cssvariable } from './use-css-variable/use-css-variable.js';
+export { download } from './use-download/use-download.js';
 export { focus } from './use-focus/use-focus.js';

--- a/packages/svelteui-actions/src/lib/types/events.d.ts
+++ b/packages/svelteui-actions/src/lib/types/events.d.ts
@@ -2,5 +2,7 @@ declare namespace svelte.JSX {
 	interface HTMLProps<T> {
 		onuseclipboard?: (event: CustomEvent<string>) => void;
 		'onuseclipboard-error'?: (event: CustomEvent<string>) => void;
+		onusedownload?: (event: CustomEvent<Blob>) => void;
+		'onusedownload-error'?: (event: CustomEvent<Blob>) => void;
 	}
 }

--- a/packages/svelteui-actions/src/lib/types/events.d.ts
+++ b/packages/svelteui-actions/src/lib/types/events.d.ts
@@ -2,7 +2,7 @@ declare namespace svelte.JSX {
 	interface HTMLProps<T> {
 		onuseclipboard?: (event: CustomEvent<string>) => void;
 		'onuseclipboard-error'?: (event: CustomEvent<string>) => void;
-		onusedownload?: (event: CustomEvent<Blob>) => void;
-		'onusedownload-error'?: (event: CustomEvent<Blob>) => void;
+		onusedownload?: (event: CustomEvent<{ blob: Blob, filename: string }>) => void;
+		'onusedownload-error'?: (event: CustomEvent<{ blob: Blob, filename: string }>) => void;
 	}
 }

--- a/packages/svelteui-actions/src/lib/use-download/use-download.ts
+++ b/packages/svelteui-actions/src/lib/use-download/use-download.ts
@@ -21,10 +21,10 @@ export function download(node: HTMLElement, params: { blob: Blob; filename: stri
             setTimeout(function() {
                 document.body.removeChild(anchor);
                 window.URL.revokeObjectURL(url);
-                node.dispatchEvent(new CustomEvent('usedownload', { detail: blob }));
+                node.dispatchEvent(new CustomEvent('usedownload', { detail: { blob: blob, filename: filename } }));
             });
         } catch(e) {
-            node.dispatchEvent(new CustomEvent('usedownload-error', { detail: blob }));
+            node.dispatchEvent(new CustomEvent('usedownload-error', { detail: { blob: blob, filename: filename } }));
         }
 	};
 

--- a/packages/svelteui-actions/src/lib/use-download/use-download.ts
+++ b/packages/svelteui-actions/src/lib/use-download/use-download.ts
@@ -1,0 +1,37 @@
+import type { Action } from '../types/_types';
+
+/**
+ * Downloads a given Blob object as a file with the given filename.
+ * 
+ * @param node HTMLElement that the action is applied to
+ * @param text The text that you want to be copied when the DOM element is clicked
+ * @example <button use:download={{ blob: new Blob([]), filename: "file.txt" }}>Download</button>
+ */
+export function download(node: HTMLElement, params: { blob: Blob; filename: string }): ReturnType<Action> {
+    const { blob, filename } = params;
+
+	const click = async () => {
+        try {
+            const anchor: HTMLAnchorElement = document.createElement("a");
+            const url: string = URL.createObjectURL(blob);
+            anchor.href = url;
+            anchor.download = filename || "";
+            document.body.appendChild(anchor);
+            anchor.click();
+            setTimeout(function() {
+                document.body.removeChild(anchor);
+                window.URL.revokeObjectURL(url);
+                node.dispatchEvent(new CustomEvent('usedownload', { detail: blob }));
+            });
+        } catch(e) {
+            node.dispatchEvent(new CustomEvent('usedownload-error', { detail: blob }));
+        }
+	};
+
+	node.addEventListener('click', click, true);
+
+	return {
+		update: (params: { blob: Blob; filename: string }) => (params = params),
+		destroy: () => node.removeEventListener('click', click, true)
+	};
+}


### PR DESCRIPTION
## Feature

New action `use-download` that allows the download of a file (by using `Blob`) through the browser.

![use-download](https://user-images.githubusercontent.com/25725586/159118482-f4e7e742-4147-4067-a439-3da3be0c754c.gif)