### PR TITLE
Focus ring

### DIFF
--- a/packages/svelteui-core/src/lib/Button/Button.svelte
+++ b/packages/svelteui-core/src/lib/Button/Button.svelte
@@ -54,6 +54,7 @@
 
 	/** Css function to generate button styles */
 	const ButtonStyles = css({
+		focusRing: 'auto',
 		cursor: 'pointer',
 		position: 'relative',
 		boxSizing: 'border-box',

--- a/packages/svelteui-core/src/lib/_styles/SvelteUiGlobal.ts
+++ b/packages/svelteui-core/src/lib/_styles/SvelteUiGlobal.ts
@@ -1,0 +1,7 @@
+import { globalCss } from './index';
+
+export const SvelteUIGlobalCSS = globalCss({
+	a: {
+		focusRing: 'auto'
+	}
+});

--- a/packages/svelteui-core/src/lib/_styles/index.ts
+++ b/packages/svelteui-core/src/lib/_styles/index.ts
@@ -6,9 +6,11 @@ export {
 	theme,
 	config,
 	createTheme,
+	globalCss,
 	css,
 	getCssText,
 	keyframes,
 	NormalizeCSS,
 	dark
 } from '../../../stitches.config';
+export { SvelteUIGlobalCSS } from './SvelteUiGlobal';

--- a/packages/svelteui-core/src/routes/__layout.svelte
+++ b/packages/svelteui-core/src/routes/__layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { NormalizeCSS, SvelteUIProvider, css, dark } from '$lib';
+	import { NormalizeCSS, SvelteUIProvider, css, dark, SvelteUIGlobalCSS } from '$lib';
 	import { Button } from '$lib';
 
 	let darkMode: boolean = false;
@@ -19,6 +19,7 @@
 	});
 
 	NormalizeCSS();
+	SvelteUIGlobalCSS();
 </script>
 
 <SvelteUIProvider themeObserver={darkMode ? 'dark' : 'light'}>

--- a/packages/svelteui-core/src/routes/index.svelte
+++ b/packages/svelteui-core/src/routes/index.svelte
@@ -2,6 +2,7 @@
 	import { Button, Code, Image, Loader, Switch, BackgroundImage } from '$lib';
 </script>
 
+<!-- <a href="#">Test url</a> -->
 <!-- <Button /> -->
 <!-- <Loader /> -->
 <!-- <Code color="dark">{'text'}</Code> -->

--- a/packages/svelteui-core/src/routes/index.svelte
+++ b/packages/svelteui-core/src/routes/index.svelte
@@ -2,7 +2,7 @@
 	import { Button, Code, Image, Loader, Switch, BackgroundImage } from '$lib';
 </script>
 
-<!-- <a href="#">Test url</a> -->
+<!-- <a href="/">Test url</a> -->
 <!-- <Button /> -->
 <!-- <Loader /> -->
 <!-- <Code color="dark">{'text'}</Code> -->

--- a/packages/svelteui-core/stitches.config.ts
+++ b/packages/svelteui-core/stitches.config.ts
@@ -1,5 +1,6 @@
 import { createStitches } from '@stitches/core';
 import { colors } from '$lib/_styles/index';
+import type { CSS } from '@stitches/core/types/css-util';
 
 export const { css, globalCss, keyframes, getCssText, theme, createTheme, config } = createStitches(
 	{
@@ -62,14 +63,26 @@ export const { css, globalCss, keyframes, getCssText, theme, createTheme, config
 			xxl: '(min-width: 1536px)'
 		},
 		utils: {
-			size: (value) => ({
+			size: (value: number | string): CSS => ({
 				width: value,
 				height: value
+			}),
+			focusRing: (value: 'auto' | 'always' | 'never'): CSS => ({
+				WebkitTapHighlightColor: 'transparent',
+
+				'&:focus': {
+					outlineOffset: 2,
+					outline: value === 'always' || value === 'auto' ? '2px solid $primary' : 'none'
+				},
+
+				'&:focus:not(:focus-visible)': {
+					outline: value === 'auto' || value === 'never' ? 'none' : undefined
+				}
 			})
 		}
 	}
 );
-
+console.log(config);
 /** Function for dark theme */
 const dark = createTheme('dark-theme', {
 	colors: {
@@ -254,7 +267,8 @@ const NormalizeCSS = globalCss({
 
 	a: {
 		background: 'transparent',
-		textDecorationSkip: 'objects'
+		textDecorationSkip: 'objects',
+		focusRing: 'auto'
 	},
 
 	'a:active, a:hover': {

--- a/packages/svelteui-core/stitches.config.ts
+++ b/packages/svelteui-core/stitches.config.ts
@@ -82,7 +82,7 @@ export const { css, globalCss, keyframes, getCssText, theme, createTheme, config
 		}
 	}
 );
-console.log(config);
+
 /** Function for dark theme */
 const dark = createTheme('dark-theme', {
 	colors: {
@@ -267,8 +267,7 @@ const NormalizeCSS = globalCss({
 
 	a: {
 		background: 'transparent',
-		textDecorationSkip: 'objects',
-		focusRing: 'auto'
+		textDecorationSkip: 'objects'
 	},
 
 	'a:active, a:hover': {


### PR DESCRIPTION
# Feature
Focus ring similar to mantine's. 
By default visible only by keyboard navigation but with the possibility to configure this behavior.

Usage:
```javascript
css({
    // possible variants: auto, always, never
    focusRing: 'auto',
})
```

# Notes
We need to figure out how to set the value for the focus ring once in configuration/theming.