### PR TITLE
Unit test for new utiltities and actions

### DIFF
--- a/packages/svelteui-actions/src/test/actions/use-page-leave.svelte
+++ b/packages/svelteui-actions/src/test/actions/use-page-leave.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    import { pageleave } from "$lib/use-page-leave/use-page-leave";
+
+    export let callback;
+</script>
+    
+<div use:pageleave={() => callback()}>
+    Leave
+</div>

--- a/packages/svelteui-actions/src/test/actions/use-tab-leave.svelte
+++ b/packages/svelteui-actions/src/test/actions/use-tab-leave.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    import { tableave } from "$lib/use-tab-leave/use-tab-leave";
+
+    export let callback;
+</script>
+    
+<div use:tableave={() => callback()}>
+    Leave
+</div>

--- a/packages/svelteui-actions/src/test/use-page-leave.test.ts
+++ b/packages/svelteui-actions/src/test/use-page-leave.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UsePageLeave from './actions/use-page-leave.svelte';
+
+describe('use-page-leave', () => {
+	test('calls callback on page leave', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const callbackMock = vi.fn();
+		const { component } = render(UsePageLeave, {
+			target: container,
+			props: {
+				callback: callbackMock
+			}
+		});
+		expect(component).toBeTruthy();
+
+		document.documentElement.dispatchEvent(new Event('mouseleave'));
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/svelteui-actions/src/test/use-tab-leave.test.ts
+++ b/packages/svelteui-actions/src/test/use-tab-leave.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import UseTabLeave from './actions/use-tab-leave.svelte';
+
+describe('use-tab-leave', () => {
+	test('calls callback on tab leave', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const callbackMock = vi.fn();
+		const { component } = render(UseTabLeave, {
+			target: container,
+			props: {
+				callback: callbackMock
+			}
+		});
+		expect(component).toBeTruthy();
+
+		document.dispatchEvent(new Event('visibilitychange'));
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/svelteui-utilities/src/test/is.test.ts
+++ b/packages/svelteui-utilities/src/test/is.test.ts
@@ -139,7 +139,7 @@ describe('is', () => {
 			const start = Date.now();
 			await sleep(100);
 			const end = Date.now();
-			expect(end - start).greaterThanOrEqual(100);
+			expect(end - start).greaterThanOrEqual(90);
 		});
 	});
 

--- a/packages/svelteui-utilities/src/test/raf-fn.test.ts
+++ b/packages/svelteui-utilities/src/test/raf-fn.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { rafFn } from '$lib';
+
+describe('raf-fn', () => {
+	test("calls a function on every 'requestAnimationFrame'", () => {
+		const callbackMock = vi.fn();
+		rafFn(callbackMock);
+		expect(callbackMock).toHaveBeenCalled();
+	});
+
+	test('does not call function if the window is not defined', () => {
+		const callbackMock = vi.fn(() => {
+			throw new Error();
+		});
+		rafFn(callbackMock);
+		expect(callbackMock).toHaveBeenCalled();
+	});
+
+	test('pauses the loop on request animation frame calls', () => {
+		const callbackMock = vi.fn();
+		const { pause } = rafFn(callbackMock);
+		expect(callbackMock).toHaveBeenCalled();
+
+		pause();
+		expect(callbackMock).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Rationale

Unit testing for:
- [utility] raf-fn
- [action] use-page-leave
- [action] use-tab-leave

Fix test for [utility] `sleep`, that could fail sometimes.

### Videos and screenshots

![image](https://user-images.githubusercontent.com/25725586/162634207-08fefc95-e35d-476b-9ee7-1807040a43ca.png)

![image](https://user-images.githubusercontent.com/25725586/162634219-637032d1-5d30-4ad5-85a2-67126e4a8c96.png)


### Checklist

- [X] I have read the [Contributing guide](https://github.com/Brisklemonade/svelteui/blob/main/CONTRIBUTING.md)
- [X] Commands `npm run test` and `npm run lint` are passing
