### PR TITLE
Fix time failing test

### DIFF
--- a/packages/svelteui-utilities/src/test/example.test.ts
+++ b/packages/svelteui-utilities/src/test/example.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
-test('example test', async () => {
-	expect(1 + 1).eq(2);
+describe('example', () => {
+	test('example test', async () => {
+		expect(1 + 1).eq(2);
+	});
 });

--- a/packages/svelteui-utilities/src/test/time.test.ts
+++ b/packages/svelteui-utilities/src/test/time.test.ts
@@ -5,8 +5,12 @@ import { dateTimeString } from '$lib';
 describe('time', () => {
 	test('returns a date time string based on locale', () => {
 		const timestamp = Date.parse('25 Apr 1974 22:55:00 GMT');
-		let result = dateTimeString(timestamp, 'en-US');
-		expect(result).eq('4/25/74, 11:55 PM');
+		let result = dateTimeString(timestamp, 'en-US', {
+			dateStyle: 'short',
+			timeStyle: 'short',
+			timeZone: 'utc'
+		});
+		expect(result).eq('4/25/74, 10:55 PM');
 
 		result = dateTimeString(timestamp, 'en-US', { dateStyle: 'full', timeStyle: 'medium' });
 		expect(result).eq('Thursday, April 25, 1974 at 11:55:00 PM');

--- a/packages/svelteui-utilities/src/test/time.test.ts
+++ b/packages/svelteui-utilities/src/test/time.test.ts
@@ -12,14 +12,26 @@ describe('time', () => {
 		});
 		expect(result).eq('4/25/74, 10:55 PM');
 
-		result = dateTimeString(timestamp, 'en-US', { dateStyle: 'full', timeStyle: 'medium' });
-		expect(result).eq('Thursday, April 25, 1974 at 11:55:00 PM');
+		result = dateTimeString(timestamp, 'en-US', {
+			dateStyle: 'full',
+			timeStyle: 'medium',
+			timeZone: 'utc'
+		});
+		expect(result).eq('Thursday, April 25, 1974 at 10:55:00 PM');
 
-		result = dateTimeString(timestamp, 'en-US', { dateStyle: 'medium', timeStyle: 'medium' });
-		expect(result).eq('Apr 25, 1974, 11:55:00 PM');
+		result = dateTimeString(timestamp, 'en-US', {
+			dateStyle: 'medium',
+			timeStyle: 'medium',
+			timeZone: 'utc'
+		});
+		expect(result).eq('Apr 25, 1974, 10:55:00 PM');
 
-		result = dateTimeString(timestamp, 'pt', { dateStyle: 'full', timeStyle: 'medium' });
-		expect(result).eq('quinta-feira, 25 de abril de 1974 23:55:00');
+		result = dateTimeString(timestamp, 'pt', {
+			dateStyle: 'full',
+			timeStyle: 'medium',
+			timeZone: 'utc'
+		});
+		expect(result).eq('quinta-feira, 25 de abril de 1974 22:55:00');
 
 		result = dateTimeString(timestamp, 'pt', {
 			dateStyle: 'full',


### PR DESCRIPTION
## Rationale

Fix utility `time` failing test in CI. It should be using UTC to circumvent timezone problems

### Checklist

- [X] I have read the [Contributing guide](https://github.com/Brisklemonade/svelteui/blob/main/CONTRIBUTING.md)
- [X] Command `npm run repo:prepush` passing
